### PR TITLE
Improve ambient traffic spawning & LOS despawn

### DIFF
--- a/scripts/Game/Components/SCR_AmbientTrafficManager.c
+++ b/scripts/Game/Components/SCR_AmbientTrafficManager.c
@@ -769,6 +769,11 @@ class SCR_AmbientTrafficManager
             toVehicle.Normalize();
 
             float dotProduct = vector.Dot(playerDir, toVehicle);
+            // Clamp to valid domain for Acos to avoid NaN due to floating point drift
+            if (dotProduct > 1.0)
+                dotProduct = 1.0;
+            else if (dotProduct < -1.0)
+                dotProduct = -1.0;
             float viewAngle = Math.Acos(dotProduct) * Math.RAD2DEG;
 
             // Only trace if within ~110 degree FOV (peripheral vision)

--- a/scripts/Game/Components/SCR_AmbientTrafficManager.c
+++ b/scripts/Game/Components/SCR_AmbientTrafficManager.c
@@ -247,6 +247,17 @@ class SCR_AmbientTrafficManager
 
         EntitySpawnParams params = new EntitySpawnParams();
         params.TransformMode = ETransformMode.WORLD;
+
+        // Derive spawn orientation from road direction (spawnPos -> destPos)
+        vector forward = vector.Direction(spawnPos, destPos);
+        // Fallback to a default forward direction if points are (almost) identical
+        if (forward.LengthSq() < 0.0001)
+            forward = "0 0 1";
+
+        vector up = "0 1 0";
+        // Build a transform matrix with the desired forward and up vectors
+        Math3D.DirectionAndUpMatrix(forward, up, params.Transform);
+        // Ensure the position is set to the chosen spawn position
         params.Transform[3] = spawnPos;
 
         // 1. Spawn Group

--- a/scripts/Game/Components/SCR_AmbientTrafficManager.c
+++ b/scripts/Game/Components/SCR_AmbientTrafficManager.c
@@ -694,10 +694,13 @@ class SCR_AmbientTrafficManager
         m_mVehicleDestinations.Remove(veh);
         m_mLastLOSCheck.Remove(veh);
 
+        // Capture identifying info before deletion
+        string vehDesc = string.Format("%1", veh);
+
         // Delete the entity
         SCR_EntityHelper.DeleteEntityAndChildren(veh);
 
-        Print(string.Format("[TRAFFIC] Cleaned up vehicle %1", veh), LogLevel.DEBUG);
+        Print(string.Format("[TRAFFIC] Cleaned up vehicle %1", vehDesc), LogLevel.DEBUG);
     }
 
     protected vector GetRandomMapPos()

--- a/scripts/Game/Components/SCR_AmbientTrafficManager.c
+++ b/scripts/Game/Components/SCR_AmbientTrafficManager.c
@@ -46,6 +46,11 @@ class SCR_TrafficEvents
 {
     // Global hook: (Position, "gunfight" or "killed")
     static ref ScriptInvoker<vector, string> OnCivilianEvent = new ScriptInvoker<vector, string>();
+    
+    // Backwards-compatible hooks for traffic vehicle lifecycle events
+    // These invokers are kept to avoid breaking existing mods/systems that subscribe to them.
+    static ref ScriptInvoker<IEntity> OnTrafficVehicleSpawned = new ScriptInvoker<IEntity>();
+    static ref ScriptInvoker<IEntity> OnTrafficVehicleDespawned = new ScriptInvoker<IEntity>();
 }
 
 class SCR_AmbientTrafficManager


### PR DESCRIPTION
Refactor SCR_AmbientTrafficManager to improve stability and prevent premature despawns. Adds LOS-based visibility checks (IsVehicleVisibleToAnyPlayer, HasLineOfSight) with per-vehicle throttling, a CleanupVehicle helper, and new tracking map for last LOS checks. Harden SpawnSingleTrafficUnit: better error handling/logging, corrected spawn transform usage, more robust AI/driver linking and vehicle startup, and reduced clustering. Initialization is auto-scheduled on game start and via SCR_PlayerController (single init), while old Shutdown/ResetInstance logic and spawn/despawn event invokers were removed. Also small fixes: release handbrake on start, debug logs, and minor debug/cleanup improvements.